### PR TITLE
feat: Add tool sets filtering feature to reduce complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,49 @@ A Model Context Protocol (MCP) implementation for Financial Modeling Prep, enabl
 - [Issues and Bug Reports](#issues-and-bug-reports)
 - [License](#license)
 
+## Features
+
+- **Comprehensive Coverage**: Access to 253+ financial tools across 24 categories
+- **Tool Set Filtering**: Load only the tools you need to reduce complexity and improve performance
+- **Real-time Data**: Live stock quotes, market data, and financial information
+- **Financial Statements**: Income statements, balance sheets, cash flow statements, and financial ratios
+- **Market Analysis**: Technical indicators, analyst estimates, and market performance metrics
+- **Economic Data**: Treasury rates, economic indicators, and macroeconomic information
+- **Alternative Data**: ESG scores, insider trading, congressional trading, and social sentiment
+
+## Tool Sets
+
+Instead of loading all 253 tools, you can specify which tool sets to load based on your needs:
+
+### Available Tool Sets
+
+| Tool Set | Description | Example Tools |
+|----------|-------------|---------------|
+| `search` | Search & Directory | Search stocks, company lookup, symbol directories |
+| `company` | Company Profile & Info | Company profiles, executives, employee count |
+| `quotes` | Real-time Quotes | Live stock prices, market data, price changes |
+| `statements` | Financial Statements | Income statements, balance sheets, cash flow, ratios |
+| `calendar` | Financial Calendar | Earnings calendar, dividends, IPOs, stock splits |
+| `charts` | Price Charts & History | Historical prices, technical charts, market movements |
+| `news` | Financial News | Market news, press releases, financial articles |
+| `analyst` | Analyst Coverage | Price targets, ratings, analyst estimates |
+| `market-performance` | Market Performance | Sector performance, gainers, losers, most active |
+| `insider-trades` | Insider Trading | Corporate insider activity, ownership changes |
+| `institutional` | Institutional Holdings | 13F filings, fund holdings, institutional ownership |
+| `indexes` | Market Indexes | S&P 500, NASDAQ, Dow Jones, index constituents |
+| `economics` | Economic Data | Treasury rates, GDP, inflation, economic indicators |
+| `crypto` | Cryptocurrency | Crypto prices, market data, digital assets |
+| `forex` | Foreign Exchange | Currency pairs, exchange rates, forex data |
+| `commodities` | Commodities | Gold, oil, agricultural products, futures |
+| `etf-funds` | ETFs & Mutual Funds | Fund holdings, performance, fund information |
+| `esg` | ESG & Sustainability | Environmental, social, governance ratings |
+| `technical-indicators` | Technical Indicators | RSI, SMA, EMA, MACD, Bollinger Bands |
+| `senate` | Government Trading | Congressional and Senate trading disclosures |
+| `sec-filings` | SEC Filings | 10-K, 10-Q, 8-K filings, regulatory documents |
+| `earnings` | Earnings & Transcripts | Earnings reports, call transcripts |
+| `dcf` | DCF Valuation | Discounted cash flow models, valuations |
+| `bulk` | Bulk Data | Large-scale data downloads for analysis |
+
 ## Usage
 
 ### Production via Smithery Registry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "financial-modeling-prep-mcp-server",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "financial-modeling-prep-mcp-server",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_API_KEY = "PLACEHOLDER_TOKEN_FOR_TOOL_LISTING";
+
+export * from "./toolSets.js";

--- a/src/constants/toolSets.ts
+++ b/src/constants/toolSets.ts
@@ -1,0 +1,246 @@
+/**
+ * Tool sets configuration based on Financial Modeling Prep API categories
+ * Each set contains related functionality that users might want to access together
+ */
+
+export type ToolSet =
+  | "search"
+  | "company"
+  | "quotes"
+  | "statements"
+  | "calendar"
+  | "charts"
+  | "news"
+  | "analyst"
+  | "market-performance"
+  | "insider-trades"
+  | "institutional"
+  | "indexes"
+  | "economics"
+  | "crypto"
+  | "forex"
+  | "commodities"
+  | "etf-funds"
+  | "esg"
+  | "technical-indicators"
+  | "senate"
+  | "sec-filings"
+  | "earnings"
+  | "dcf"
+  | "bulk";
+
+export interface ToolSetDefinition {
+  name: string;
+  description: string;
+  modules: string[];
+}
+
+/**
+ * Comprehensive tool sets mapping based on FMP API structure
+ */
+export const TOOL_SETS: Record<ToolSet, ToolSetDefinition> = {
+  // Basic search and discovery
+  search: {
+    name: "Search & Directory",
+    description:
+      "Search for stocks, company information, and directory services",
+    modules: ["search", "directory"],
+  },
+
+  // Core company data
+  company: {
+    name: "Company Profile & Info",
+    description:
+      "Company profiles, executives, employees, and core business information",
+    modules: ["company"],
+  },
+
+  // Real-time market data
+  quotes: {
+    name: "Real-time Quotes",
+    description: "Real-time stock quotes, price changes, and market data",
+    modules: ["quotes"],
+  },
+
+  // Financial statements and analysis
+  statements: {
+    name: "Financial Statements",
+    description:
+      "Income statements, balance sheets, cash flow, ratios, and financial analysis",
+    modules: ["statements"],
+  },
+
+  // Events and calendar data
+  calendar: {
+    name: "Financial Calendar",
+    description:
+      "Earnings calendar, dividends, IPOs, stock splits, and corporate events",
+    modules: ["calendar", "earnings-transcript"],
+  },
+
+  // Price charts and historical data
+  charts: {
+    name: "Price Charts & History",
+    description: "Historical price data, charts, and market movements",
+    modules: ["chart"],
+  },
+
+  // News and press releases
+  news: {
+    name: "Financial News",
+    description: "Market news, press releases, and financial articles",
+    modules: ["news"],
+  },
+
+  // Analyst coverage
+  analyst: {
+    name: "Analyst Coverage",
+    description:
+      "Analyst estimates, price targets, ratings, and recommendations",
+    modules: ["analyst"],
+  },
+
+  // Market performance metrics
+  "market-performance": {
+    name: "Market Performance",
+    description:
+      "Sector performance, market movements, gainers, losers, and most active stocks",
+    modules: ["market-performance", "market-hours"],
+  },
+
+  // Insider trading data
+  "insider-trades": {
+    name: "Insider Trading",
+    description: "Corporate insider trading activity and ownership changes",
+    modules: ["insider-trades"],
+  },
+
+  // Institutional ownership
+  institutional: {
+    name: "Institutional Holdings",
+    description: "13F filings, institutional ownership, and fund holdings",
+    modules: ["form-13f"],
+  },
+
+  // Market indexes
+  indexes: {
+    name: "Market Indexes",
+    description: "Stock market indexes, constituents, and index performance",
+    modules: ["indexes"],
+  },
+
+  // Economic data
+  economics: {
+    name: "Economic Data",
+    description: "Treasury rates, economic indicators, and macroeconomic data",
+    modules: ["economics", "cot"],
+  },
+
+  // Cryptocurrency data
+  crypto: {
+    name: "Cryptocurrency",
+    description: "Cryptocurrency prices, charts, and market data",
+    modules: ["crypto"],
+  },
+
+  // Foreign exchange
+  forex: {
+    name: "Foreign Exchange",
+    description: "Currency pairs, forex rates, and foreign exchange data",
+    modules: ["forex"],
+  },
+
+  // Commodities trading
+  commodities: {
+    name: "Commodities",
+    description: "Commodity prices, futures, and commodity market data",
+    modules: ["commodity"],
+  },
+
+  // ETFs and mutual funds
+  "etf-funds": {
+    name: "ETFs & Mutual Funds",
+    description: "ETF and mutual fund holdings, performance, and information",
+    modules: ["fund", "fundraisers"],
+  },
+
+  // ESG and sustainability
+  esg: {
+    name: "ESG & Sustainability",
+    description: "Environmental, Social, and Governance ratings and data",
+    modules: ["esg"],
+  },
+
+  // Technical analysis
+  "technical-indicators": {
+    name: "Technical Indicators",
+    description: "Technical analysis indicators like RSI, SMA, EMA, and more",
+    modules: ["technical-indicators"],
+  },
+
+  // Government trading
+  senate: {
+    name: "Government Trading",
+    description: "Congressional and Senate trading disclosures",
+    modules: ["government-trading"],
+  },
+
+  // SEC filings
+  "sec-filings": {
+    name: "SEC Filings",
+    description: "SEC filings, regulatory documents, and corporate disclosures",
+    modules: ["sec-filings"],
+  },
+
+  // Earnings and transcripts
+  earnings: {
+    name: "Earnings & Transcripts",
+    description: "Earnings reports, call transcripts, and earnings analysis",
+    modules: ["earnings-transcript"],
+  },
+
+  // Valuation models
+  dcf: {
+    name: "DCF Valuation",
+    description: "Discounted cash flow models and company valuations",
+    modules: ["dcf"],
+  },
+
+  // Bulk data access
+  bulk: {
+    name: "Bulk Data",
+    description: "Bulk data downloads for large-scale analysis",
+    modules: ["bulk"],
+  },
+};
+
+/**
+ * Get modules for the specified tool sets
+ * @param toolSets Array of tool set names to load
+ * @returns Array of module names to register
+ */
+export function getModulesForToolSets(toolSets: ToolSet[]): string[] {
+  const modules = new Set<string>();
+
+  for (const toolSet of toolSets) {
+    const definition = TOOL_SETS[toolSet];
+    if (definition) {
+      definition.modules.forEach((module) => modules.add(module));
+    }
+  }
+
+  return Array.from(modules);
+}
+
+/**
+ * Get all available tool sets for help/documentation
+ */
+export function getAvailableToolSets(): Array<{
+  key: ToolSet;
+  definition: ToolSetDefinition;
+}> {
+  return Object.entries(TOOL_SETS).map(([key, definition]) => ({
+    key: key as ToolSet,
+    definition,
+  }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,23 +2,87 @@
 
 import minimist from "minimist";
 import { startServer } from "./server/server.js";
+import { type ToolSet, getAvailableToolSets } from "./constants/index.js";
 
 // Parse command line arguments
 const argv = minimist(process.argv.slice(2));
+
+// Show help if requested
+if (argv.help || argv.h) {
+  showHelp();
+  process.exit(0);
+}
 
 // Get configuration from environment variables and command line
 const port = process.env.PORT ? parseInt(process.env.PORT) : 3000;
 const fmpToken = argv["fmp-token"] || process.env.FMP_ACCESS_TOKEN;
 
-startServer({ port });
+// Parse toolSets argument
+let toolSets: ToolSet[] = [];
+if (argv["tool-sets"] || argv["toolSets"]) {
+  const toolSetsInput = argv["tool-sets"] || argv["toolSets"];
+  if (typeof toolSetsInput === "string") {
+    toolSets = toolSetsInput.split(",").map((s) => s.trim()) as ToolSet[];
+  }
+}
+
+// Validate tool sets
+const availableToolSets = getAvailableToolSets().map(({ key }) => key);
+const invalidToolSets = toolSets.filter(
+  (ts) => !availableToolSets.includes(ts)
+);
+if (invalidToolSets.length > 0) {
+  console.error(`Invalid tool sets: ${invalidToolSets.join(", ")}`);
+  console.error(`Available tool sets: ${availableToolSets.join(", ")}`);
+  process.exit(1);
+}
+
+startServer({ port, toolSets });
 
 // Log startup information
 if (fmpToken) {
-  console.log("Financial Modeling Prep MCP server initialized successfully with API token");
+  console.log(
+    "Financial Modeling Prep MCP server initialized successfully with API token"
+  );
 } else {
   console.log("Financial Modeling Prep MCP server initialized successfully");
   console.log("Note: API token can be provided via:");
   console.log("  - Environment variable: FMP_ACCESS_TOKEN");
   console.log("  - Command line argument: --fmp-token");
   console.log("  - Smithery configuration when using with Smithery");
+}
+
+function showHelp() {
+  console.log(`
+Financial Modeling Prep MCP Server
+
+Usage: npm start [options]
+
+Options:
+  --port <number>              Server port (default: 3000)
+  --fmp-token <token>          FMP API access token
+  --tool-sets <sets>           Comma-separated list of tool sets to load
+  --help, -h                   Show this help message
+
+Available Tool Sets:
+`);
+
+  const toolSets = getAvailableToolSets();
+  toolSets.forEach(({ key, definition }) => {
+    console.log(`  ${key.padEnd(20)} ${definition.name}`);
+    console.log(`  ${" ".repeat(20)} ${definition.description}`);
+    console.log();
+  });
+
+  console.log(`
+Examples:
+  npm start                                    # Load all tools (253 tools)
+  npm start -- --tool-sets search,company     # Load only search and company tools
+  npm start -- --tool-sets quotes,charts      # Load only quotes and charts tools
+  npm start -- --port 4000 --tool-sets crypto,forex  # Custom port with crypto and forex tools
+
+Environment Variables:
+  PORT              Server port
+  FMP_ACCESS_TOKEN  Financial Modeling Prep API access token
+`);
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -27,6 +27,80 @@ import { registerEarningsTranscriptTools } from "./earnings-transcript.js";
 import { registerSECFilingsTools } from "./sec-filings.js";
 import { registerGovernmentTradingTools } from "./government-trading.js";
 import { registerBulkTools } from "./bulk.js";
+import type { ToolSet } from "../constants/index.js";
+import { getModulesForToolSets } from "../constants/index.js";
+
+/**
+ * Module registration function mapping
+ */
+const MODULE_REGISTRATIONS = {
+  search: registerSearchTools,
+  directory: registerDirectoryTools,
+  analyst: registerAnalystTools,
+  calendar: registerCalendarTools,
+  chart: registerChartTools,
+  company: registerCompanyTools,
+  cot: registerCOTTools,
+  esg: registerESGTools,
+  economics: registerEconomicsTools,
+  dcf: registerDCFTools,
+  fund: registerFundTools,
+  commodity: registerCommodityTools,
+  fundraisers: registerFundraisersTools,
+  crypto: registerCryptoTools,
+  forex: registerForexTools,
+  statements: registerStatementsTools,
+  "form-13f": registerForm13FTools,
+  indexes: registerIndexesTools,
+  "insider-trades": registerInsiderTradesTools,
+  "market-performance": registerMarketPerformanceTools,
+  "market-hours": registerMarketHoursTools,
+  news: registerNewsTools,
+  "technical-indicators": registerTechnicalIndicatorsTools,
+  quotes: registerQuotesTools,
+  "earnings-transcript": registerEarningsTranscriptTools,
+  "sec-filings": registerSECFilingsTools,
+  "government-trading": registerGovernmentTradingTools,
+  bulk: registerBulkTools,
+} as const;
+
+/**
+ * Register tools based on specified tool sets
+ * @param server The MCP server instance
+ * @param toolSets Array of tool set names to load (if empty, loads all tools)
+ * @param accessToken The Financial Modeling Prep API access token (optional when using lazy loading)
+ */
+export function registerToolsBySet(
+  server: McpServer,
+  toolSets: ToolSet[],
+  accessToken?: string
+): void {
+  // If no tool sets specified, load all tools for backward compatibility
+  if (toolSets.length === 0) {
+    registerAllTools(server, accessToken);
+    return;
+  }
+
+  // Get the modules that should be loaded for the specified tool sets
+  const modulesToLoad = getModulesForToolSets(toolSets);
+
+  // Register each required module
+  for (const moduleName of modulesToLoad) {
+    const registrationFunction =
+      MODULE_REGISTRATIONS[moduleName as keyof typeof MODULE_REGISTRATIONS];
+    if (registrationFunction) {
+      registrationFunction(server, accessToken);
+    } else {
+      console.warn(`Unknown module: ${moduleName}`);
+    }
+  }
+
+  console.log(
+    `Loaded ${modulesToLoad.length} modules for tool sets: ${toolSets.join(
+      ", "
+    )}`
+  );
+}
 
 /**
  * Register all tools with the MCP server


### PR DESCRIPTION
- Add 24 predefined tool sets based on FMP API categorization
- Allow loading specific tool sets instead of all 253 tools
- Add --tool-sets command line argument with comma-separated values
- Maintain backward compatibility (no args = load all tools)
- Add comprehensive help documentation with tool set descriptions
- Update README with usage examples and tool set reference
- Add validation for invalid tool set names

Examples:
- npm start -- --tool-sets search,company
- npm start -- --tool-sets quotes,charts,technical-indicators
- npm start (loads all tools for backward compatibility)

Resolves issue with tool overload by providing targeted functionality.