### PR TITLE
ci(release): bump actions/setup-go to v6 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         run: npm run build
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
 


### PR DESCRIPTION
Fixes GitHub Actions CI warnings about deprecated Node.js 20 actions.\n\nChanges:\n- Updated actions/setup-go@v5 to actions/setup-go@v6 in .github/workflows/release.yml\n\nAll workflow actions are now on Node.js 24 compatible versions:\n- actions/checkout@v6\n- actions/setup-node@v6\n- actions/setup-go@v6 (updated)\n- softprops/action-gh-release@v3