### PR TITLE
Forward-port of #98: FMPClient cleanup, options normalization, showHelp tests

### DIFF
--- a/__tests__/unit/api/analyst/AnalystClient.test.ts
+++ b/__tests__/unit/api/analyst/AnalystClient.test.ts
@@ -71,7 +71,7 @@ describe('AnalystClient', () => {
         period: 'annual',
         page: 0,
         limit: 10
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -86,7 +86,7 @@ describe('AnalystClient', () => {
         period: 'quarter',
         page: undefined,
         limit: undefined
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -121,7 +121,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/ratings-snapshot', {
         symbol: 'AAPL',
         limit: 1
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -134,7 +134,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/ratings-snapshot', {
         symbol: 'AAPL',
         limit: undefined
-      });
+      }, undefined);
     });
   });
 
@@ -161,7 +161,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/ratings-historical', {
         symbol: 'AAPL',
         limit: 100
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -174,7 +174,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/ratings-historical', {
         symbol: 'AAPL',
         limit: undefined
-      });
+      }, undefined);
     });
   });
 
@@ -200,7 +200,7 @@ describe('AnalystClient', () => {
 
       expect(mockGet).toHaveBeenCalledWith('/price-target-summary', {
         symbol: 'AAPL'
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
   });
@@ -222,7 +222,7 @@ describe('AnalystClient', () => {
 
       expect(mockGet).toHaveBeenCalledWith('/price-target-consensus', {
         symbol: 'AAPL'
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
   });
@@ -252,7 +252,7 @@ describe('AnalystClient', () => {
         symbol: 'AAPL',
         page: 0,
         limit: 10
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -266,7 +266,7 @@ describe('AnalystClient', () => {
         symbol: 'AAPL',
         page: undefined,
         limit: undefined
-      });
+      }, undefined);
     });
   });
 
@@ -294,7 +294,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/price-target-latest-news', {
         page: 0,
         limit: 10
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -307,7 +307,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/price-target-latest-news', {
         page: undefined,
         limit: undefined
-      });
+      }, undefined);
     });
   });
 
@@ -329,7 +329,7 @@ describe('AnalystClient', () => {
 
       expect(mockGet).toHaveBeenCalledWith('/grades', {
         symbol: 'AAPL'
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
   });
@@ -353,7 +353,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/grades-historical', {
         symbol: 'AAPL',
         limit: 100
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -366,7 +366,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/grades-historical', {
         symbol: 'AAPL',
         limit: undefined
-      });
+      }, undefined);
     });
   });
 
@@ -389,7 +389,7 @@ describe('AnalystClient', () => {
 
       expect(mockGet).toHaveBeenCalledWith('/grades-consensus', {
         symbol: 'AAPL'
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
   });
@@ -419,7 +419,7 @@ describe('AnalystClient', () => {
         symbol: 'AAPL',
         page: 0,
         limit: 10
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -433,7 +433,7 @@ describe('AnalystClient', () => {
         symbol: 'AAPL',
         page: undefined,
         limit: undefined
-      });
+      }, undefined);
     });
   });
 
@@ -461,7 +461,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/grades-latest-news', {
         page: 0,
         limit: 10
-      });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -474,7 +474,7 @@ describe('AnalystClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/grades-latest-news', {
         page: undefined,
         limit: undefined
-      });
+      }, undefined);
     });
   });
 

--- a/__tests__/unit/api/search/SearchClient.test.ts
+++ b/__tests__/unit/api/search/SearchClient.test.ts
@@ -57,7 +57,7 @@ describe('SearchClient', () => {
         query: 'Apple',
         limit: 10,
         exchange: 'NASDAQ'
-      }, { context: undefined });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -71,7 +71,7 @@ describe('SearchClient', () => {
         query: 'Tesla',
         limit: undefined,
         exchange: undefined
-      }, { context: undefined });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -80,7 +80,7 @@ describe('SearchClient', () => {
       mockGet.mockResolvedValue(mockData);
       const context = { config: { FMP_ACCESS_TOKEN: 'custom-token' } };
 
-      await searchClient.searchSymbol('Google', 5, 'NYSE', context);
+      await searchClient.searchSymbol('Google', 5, 'NYSE', { context });
 
       expect(mockGet).toHaveBeenCalledWith('/search-symbol', {
         query: 'Google',
@@ -117,7 +117,7 @@ describe('SearchClient', () => {
         query: 'Apple Inc',
         limit: 5,
         exchange: 'NASDAQ'
-      }, { context: undefined });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -131,7 +131,7 @@ describe('SearchClient', () => {
         query: 'Microsoft',
         limit: undefined,
         exchange: undefined
-      }, { context: undefined });
+      }, undefined);
     });
 
     it('should handle context parameter', async () => {
@@ -139,7 +139,7 @@ describe('SearchClient', () => {
       mockGet.mockResolvedValue(mockData);
       const context = { config: { FMP_ACCESS_TOKEN: 'name-token' } };
 
-      await searchClient.searchName('Tesla', 10, 'NYSE', context);
+      await searchClient.searchName('Tesla', 10, 'NYSE', { context });
 
       expect(mockGet).toHaveBeenCalledWith('/search-name', {
         query: 'Tesla',
@@ -168,7 +168,7 @@ describe('SearchClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/search-cik', {
         cik: '0000320193',
         limit: 10
-      }, { context: undefined });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -181,7 +181,7 @@ describe('SearchClient', () => {
       expect(mockGet).toHaveBeenCalledWith('/search-cik', {
         cik: '0000789019',
         limit: undefined
-      }, { context: undefined });
+      }, undefined);
     });
 
     it('should handle context parameter', async () => {
@@ -189,7 +189,7 @@ describe('SearchClient', () => {
       mockGet.mockResolvedValue(mockData);
       const context = { config: { FMP_ACCESS_TOKEN: 'cik-token' } };
 
-      await searchClient.searchCIK('0000051143', 5, context);
+      await searchClient.searchCIK('0000051143', 5, { context });
 
       expect(mockGet).toHaveBeenCalledWith('/search-cik', {
         cik: '0000051143',
@@ -214,7 +214,7 @@ describe('SearchClient', () => {
 
       expect(mockGet).toHaveBeenCalledWith('/search-cusip', {
         cusip: '037833100'
-      }, { context: undefined });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -223,7 +223,7 @@ describe('SearchClient', () => {
       mockGet.mockResolvedValue(mockData);
       const context = { config: { FMP_ACCESS_TOKEN: 'cusip-token' } };
 
-      await searchClient.searchCUSIP('594918104', context);
+      await searchClient.searchCUSIP('594918104', { context });
 
       expect(mockGet).toHaveBeenCalledWith('/search-cusip', {
         cusip: '594918104'
@@ -247,7 +247,7 @@ describe('SearchClient', () => {
 
       expect(mockGet).toHaveBeenCalledWith('/search-isin', {
         isin: 'US0378331005'
-      }, { context: undefined });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -256,7 +256,7 @@ describe('SearchClient', () => {
       mockGet.mockResolvedValue(mockData);
       const context = { config: { FMP_ACCESS_TOKEN: 'isin-token' } };
 
-      await searchClient.searchISIN('US5949181045', context);
+      await searchClient.searchISIN('US5949181045', { context });
 
       expect(mockGet).toHaveBeenCalledWith('/search-isin', {
         isin: 'US5949181045'
@@ -311,9 +311,7 @@ describe('SearchClient', () => {
 
       const result = await searchClient.stockScreener(params);
 
-      expect(mockGet).toHaveBeenCalledWith('/company-screener', params, {
-        context: undefined
-      });
+      expect(mockGet).toHaveBeenCalledWith('/company-screener', params, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -325,7 +323,7 @@ describe('SearchClient', () => {
 
       expect(mockGet).toHaveBeenCalledWith('/company-screener', {
         sector: 'Technology'
-      }, { context: undefined });
+      }, undefined);
     });
 
     it('should handle context parameter', async () => {
@@ -333,7 +331,7 @@ describe('SearchClient', () => {
       mockGet.mockResolvedValue(mockData);
       const context = { config: { FMP_ACCESS_TOKEN: 'screener-token' } };
 
-      await searchClient.stockScreener({ marketCapMoreThan: 1000000000 }, context);
+      await searchClient.stockScreener({ marketCapMoreThan: 1000000000 }, { context });
 
       expect(mockGet).toHaveBeenCalledWith('/company-screener', {
         marketCapMoreThan: 1000000000
@@ -346,9 +344,7 @@ describe('SearchClient', () => {
 
       await searchClient.stockScreener({});
 
-      expect(mockGet).toHaveBeenCalledWith('/company-screener', {}, {
-        context: undefined
-      });
+      expect(mockGet).toHaveBeenCalledWith('/company-screener', {}, undefined);
     });
   });
 
@@ -400,7 +396,7 @@ describe('SearchClient', () => {
 
       expect(mockGet).toHaveBeenCalledWith('/search-exchange-variants', {
         symbol: 'AAPL'
-      }, { context: undefined });
+      }, undefined);
       expect(result).toEqual(mockData);
     });
 
@@ -409,7 +405,7 @@ describe('SearchClient', () => {
       mockGet.mockResolvedValue(mockData);
       const context = { config: { FMP_ACCESS_TOKEN: 'variant-token' } };
 
-      await searchClient.searchExchangeVariants('MSFT', context);
+      await searchClient.searchExchangeVariants('MSFT', { context });
 
       expect(mockGet).toHaveBeenCalledWith('/search-exchange-variants', {
         symbol: 'MSFT'

--- a/__tests__/unit/utils/utils.test.ts
+++ b/__tests__/unit/utils/utils.test.ts
@@ -525,3 +525,99 @@ describe('areStringSetsEqual', () => {
     expect(areStringSetsEqual(['a'], null as any)).toBe(false);
   });
 });
+
+
+describe('showHelp', () => {
+  let localLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    localLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    localLogSpy.mockRestore();
+  });
+
+  it('writes output to console.log', async () => {
+    const { showHelp } = await import('../../../src/utils/showHelp.js');
+    showHelp([]);
+    expect(localLogSpy).toHaveBeenCalled();
+  });
+
+  it('includes the server name', async () => {
+    const { showHelp } = await import('../../../src/utils/showHelp.js');
+    showHelp([]);
+    const output = localLogSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('Financial Modeling Prep MCP Server');
+  });
+
+  it('mentions the default port from constants', async () => {
+    const { showHelp } = await import('../../../src/utils/showHelp.js');
+    const { DEFAULT_PORT } = await import('../../../src/constants/index.js');
+    showHelp([]);
+    const output = localLogSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain(String(DEFAULT_PORT));
+  });
+
+  it('lists every supplied toolset key, name, and description', async () => {
+    const { showHelp } = await import('../../../src/utils/showHelp.js');
+    const sets = [
+      {
+        key: 'search' as const,
+        definition: {
+          name: 'Search & Directory',
+          description: 'Find companies and discover investments',
+          decisionCriteria: 'Lookup symbols',
+          modules: ['search'],
+        },
+      },
+      {
+        key: 'company' as const,
+        definition: {
+          name: 'Company Profile & Info',
+          description: 'Company profiles and core business information',
+          decisionCriteria: 'Get company details',
+          modules: ['company'],
+        },
+      },
+    ];
+    showHelp(sets);
+    const output = localLogSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    for (const s of sets) {
+      expect(output).toContain(s.key);
+      expect(output).toContain(s.definition.name);
+      expect(output).toContain(s.definition.description);
+    }
+  });
+
+  it('handles an empty toolset array without throwing', async () => {
+    const { showHelp } = await import('../../../src/utils/showHelp.js');
+    expect(() => showHelp([])).not.toThrow();
+  });
+
+  it('includes documented CLI flags', async () => {
+    const { showHelp } = await import('../../../src/utils/showHelp.js');
+    showHelp([]);
+    const output = localLogSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    for (const flag of [
+      '--port',
+      '--fmp-token',
+      '--dynamic-tool-discovery',
+      '--fmp-tool-sets',
+      '--help',
+    ]) {
+      expect(output).toContain(flag);
+    }
+  });
+
+  it('documents configuration precedence and environment variables', async () => {
+    const { showHelp } = await import('../../../src/utils/showHelp.js');
+    showHelp([]);
+    const output = localLogSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('Configuration Precedence');
+    expect(output).toContain('FMP_ACCESS_TOKEN');
+    expect(output).toContain('DYNAMIC_TOOL_DISCOVERY');
+    expect(output).toContain('FMP_TOOL_SETS');
+    expect(output).toContain('PORT');
+  });
+});

--- a/src/api/FMPClient.ts
+++ b/src/api/FMPClient.ts
@@ -2,7 +2,12 @@ import axios, { type AxiosInstance, type AxiosError, type AxiosRequestConfig } f
 
 interface FMPErrorResponse {
   message: string;
-  [key: string]: any;
+  [key: string]: unknown;
+}
+
+interface RequestOptions {
+  signal?: AbortSignal;
+  context?: { config?: { FMP_ACCESS_TOKEN?: string } };
 }
 
 export class FMPClient {
@@ -18,9 +23,7 @@ export class FMPClient {
   }
 
   // Get the API key from the context or the instance
-  private getApiKey(context?: {
-    config?: { FMP_ACCESS_TOKEN?: string };
-  }): string {
+  private getApiKey(context?: RequestOptions["context"]): string {
     const configApiKey = context?.config?.FMP_ACCESS_TOKEN;
 
     if (configApiKey) {
@@ -39,131 +42,93 @@ export class FMPClient {
     return apiKey;
   }
 
+  // Build an axios request config with apikey, signal, and any extra fields merged.
+  private buildConfig(
+    params: object,
+    options: RequestOptions | undefined,
+    extra?: Partial<AxiosRequestConfig>
+  ): AxiosRequestConfig {
+    const apiKey = this.getApiKey(options?.context);
+    const config: AxiosRequestConfig = {
+      params: {
+        ...params,
+        apikey: apiKey,
+      },
+      ...extra,
+    };
+    if (options?.signal) {
+      config.signal = options.signal;
+    }
+    return config;
+  }
+
+  // Normalize axios and unknown errors into a single Error with a stable prefix.
+  // Preserves the original error as `cause` for upstream chaining.
+  private toFmpError(error: unknown): Error {
+    if (axios.isAxiosError(error)) {
+      const axiosError = error as AxiosError<FMPErrorResponse>;
+      return new Error(
+        `FMP API Error: ${
+          axiosError.response?.data?.message || axiosError.message
+        }`,
+        { cause: error }
+      );
+    }
+    return new Error(
+      `Unexpected error: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error }
+    );
+  }
+
   protected async get<T>(
     endpoint: string,
-    params: Record<string, any> = {},
-    options?: {
-      signal?: AbortSignal;
-      context?: { config?: { FMP_ACCESS_TOKEN?: string } };
-    }
+    params: object = {},
+    options?: RequestOptions
   ): Promise<T> {
     try {
-      // Try to get API key from context first, fall back to instance API key
-      const apiKey = this.getApiKey(options?.context);
-
-      const config: AxiosRequestConfig = {
-        params: {
-          ...params,
-          apikey: apiKey,
-        },
-      };
-
-      if (options?.signal) {
-        config.signal = options.signal;
-      }
-
-      const response = await this.client.get<T>(endpoint, config);
+      const response = await this.client.get<T>(
+        endpoint,
+        this.buildConfig(params, options)
+      );
       return response.data;
     } catch (error: unknown) {
-      if (axios.isAxiosError(error)) {
-        const axiosError = error as AxiosError<FMPErrorResponse>;
-        throw new Error(
-          `FMP API Error: ${
-            axiosError.response?.data?.message || axiosError.message
-          }`, { cause: error }
-        );
-      }
-      throw new Error(
-        `Unexpected error: ${
-          error instanceof Error ? error.message : String(error)
-        }`, { cause: error }
-      );
+      throw this.toFmpError(error);
     }
   }
 
   protected async getCSV(
     endpoint: string,
-    params: Record<string, any> = {},
-    options?: {
-      signal?: AbortSignal;
-      context?: { config?: { FMP_ACCESS_TOKEN?: string } };
-    }
+    params: object = {},
+    options?: RequestOptions
   ): Promise<string> {
     try {
-      // Try to get API key from context first, fall back to instance API key
-      const apiKey = this.getApiKey(options?.context);
-
-      const config: AxiosRequestConfig = {
-        params: {
-          ...params,
-          apikey: apiKey,
-        },
-        responseType: 'text', // Important: get response as text for CSV
-      };
-
-      if (options?.signal) {
-        config.signal = options.signal;
-      }
-
-      const response = await this.client.get<string>(endpoint, config);
+      const response = await this.client.get<string>(
+        endpoint,
+        this.buildConfig(params, options, { responseType: "text" })
+      );
       return response.data;
     } catch (error: unknown) {
-      if (axios.isAxiosError(error)) {
-        const axiosError = error as AxiosError<FMPErrorResponse>;
-        throw new Error(
-          `FMP API Error: ${
-            axiosError.response?.data?.message || axiosError.message
-          }`, { cause: error }
-        );
-      }
-      throw new Error(
-        `Unexpected error: ${
-          error instanceof Error ? error.message : String(error)
-        }`, { cause: error }
-      );
+      throw this.toFmpError(error);
     }
   }
 
   protected async post<T>(
     endpoint: string,
-    data: any,
-    params: Record<string, any> = {},
-    options?: {
-      signal?: AbortSignal;
-      context?: { config?: { FMP_ACCESS_TOKEN?: string } };
-    }
+    data: unknown,
+    params: object = {},
+    options?: RequestOptions
   ): Promise<T> {
     try {
-      // Try to get API key from context first, fall back to instance API key
-      const apiKey = this.getApiKey(options?.context);
-
-      const config: AxiosRequestConfig = {
-        params: {
-          ...params,
-          apikey: apiKey,
-        },
-      };
-
-      if (options?.signal) {
-        config.signal = options.signal;
-      }
-
-      const response = await this.client.post<T>(endpoint, data, config);
+      const response = await this.client.post<T>(
+        endpoint,
+        data,
+        this.buildConfig(params, options)
+      );
       return response.data;
     } catch (error: unknown) {
-      if (axios.isAxiosError(error)) {
-        const axiosError = error as AxiosError<FMPErrorResponse>;
-        throw new Error(
-          `FMP API Error: ${
-            axiosError.response?.data?.message || axiosError.message
-          }`, { cause: error }
-        );
-      }
-      throw new Error(
-        `Unexpected error: ${
-          error instanceof Error ? error.message : String(error)
-        }`, { cause: error }
-      );
+      throw this.toFmpError(error);
     }
   }
 }

--- a/src/api/analyst/AnalystClient.ts
+++ b/src/api/analyst/AnalystClient.ts
@@ -1,4 +1,5 @@
 import { FMPClient } from "../FMPClient.js";
+import type { FMPContext } from "../../types/index.js";
 import type {
   AnalystEstimate,
   RatingsSnapshot,
@@ -12,6 +13,11 @@ import type {
   StockGradeNews,
 } from "./types.js";
 
+type RequestOptions = {
+  signal?: AbortSignal;
+  context?: FMPContext;
+};
+
 export class AnalystClient extends FMPClient {
 
   /**
@@ -20,71 +26,93 @@ export class AnalystClient extends FMPClient {
    * @param period Period (annual or quarter)
    * @param page Optional page number (default: 0)
    * @param limit Optional limit on number of results (default: 10, max: 1000)
+   * @param options Optional parameters including abort signal and context
    * @returns Array of analyst estimates
    */
   async getAnalystEstimates(
     symbol: string,
     period: "annual" | "quarter",
     page?: number,
-    limit?: number
+    limit?: number,
+    options?: RequestOptions
   ): Promise<AnalystEstimate[]> {
-    return super.get<AnalystEstimate[]>("/analyst-estimates", {
-      symbol,
-      period,
-      page,
-      limit,
-    });
+    return super.get<AnalystEstimate[]>(
+      "/analyst-estimates",
+      { symbol, period, page, limit },
+      options
+    );
   }
 
   /**
    * Get ratings snapshot for a stock symbol
    * @param symbol Stock symbol
    * @param limit Optional limit on number of results (default: 1)
+   * @param options Optional parameters including abort signal and context
    * @returns Array of ratings snapshots
    */
   async getRatingsSnapshot(
     symbol: string,
-    limit?: number
+    limit?: number,
+    options?: RequestOptions
   ): Promise<RatingsSnapshot[]> {
-    return super.get<RatingsSnapshot[]>("/ratings-snapshot", { symbol, limit });
+    return super.get<RatingsSnapshot[]>(
+      "/ratings-snapshot",
+      { symbol, limit },
+      options
+    );
   }
 
   /**
    * Get historical ratings for a stock symbol
    * @param symbol Stock symbol
    * @param limit Optional limit on number of results (default: 1, max: 10000)
+   * @param options Optional parameters including abort signal and context
    * @returns Array of historical ratings
    */
   async getHistoricalRatings(
     symbol: string,
-    limit?: number
+    limit?: number,
+    options?: RequestOptions
   ): Promise<HistoricalRating[]> {
-    return super.get<HistoricalRating[]>("/ratings-historical", {
-      symbol,
-      limit,
-    });
+    return super.get<HistoricalRating[]>(
+      "/ratings-historical",
+      { symbol, limit },
+      options
+    );
   }
 
   /**
    * Get price target summary for a stock symbol
    * @param symbol Stock symbol
+   * @param options Optional parameters including abort signal and context
    * @returns Array of price target summaries
    */
-  async getPriceTargetSummary(symbol: string): Promise<PriceTargetSummary[]> {
-    return super.get<PriceTargetSummary[]>("/price-target-summary", { symbol });
+  async getPriceTargetSummary(
+    symbol: string,
+    options?: RequestOptions
+  ): Promise<PriceTargetSummary[]> {
+    return super.get<PriceTargetSummary[]>(
+      "/price-target-summary",
+      { symbol },
+      options
+    );
   }
 
   /**
    * Get price target consensus for a stock symbol
    * @param symbol Stock symbol
+   * @param options Optional parameters including abort signal and context
    * @returns Array of price target consensus
    */
   async getPriceTargetConsensus(
-    symbol: string
+    symbol: string,
+    options?: RequestOptions
   ): Promise<PriceTargetConsensus[]> {
-    return super.get<PriceTargetConsensus[]>("/price-target-consensus", {
-      symbol,
-    });
+    return super.get<PriceTargetConsensus[]>(
+      "/price-target-consensus",
+      { symbol },
+      options
+    );
   }
 
   /**
@@ -92,68 +120,88 @@ export class AnalystClient extends FMPClient {
    * @param symbol Stock symbol
    * @param page Optional page number (default: 0)
    * @param limit Optional limit on number of results (default: 10)
+   * @param options Optional parameters including abort signal and context
    * @returns Array of price target news
    */
   async getPriceTargetNews(
     symbol: string,
     page?: number,
-    limit?: number
+    limit?: number,
+    options?: RequestOptions
   ): Promise<PriceTargetNews[]> {
-    return super.get<PriceTargetNews[]>("/price-target-news", {
-      symbol,
-      page,
-      limit,
-    });
+    return super.get<PriceTargetNews[]>(
+      "/price-target-news",
+      { symbol, page, limit },
+      options
+    );
   }
 
   /**
    * Get latest price target news for all stocks
    * @param page Optional page number (default: 0, max: 100)
    * @param limit Optional limit on number of results (default: 10, max: 1000)
+   * @param options Optional parameters including abort signal and context
    * @returns Array of price target news
    */
   async getPriceTargetLatestNews(
     page?: number,
-    limit?: number
+    limit?: number,
+    options?: RequestOptions
   ): Promise<PriceTargetNews[]> {
-    return super.get<PriceTargetNews[]>("/price-target-latest-news", {
-      page,
-      limit,
-    });
+    return super.get<PriceTargetNews[]>(
+      "/price-target-latest-news",
+      { page, limit },
+      options
+    );
   }
 
   /**
    * Get stock grades for a stock symbol
    * @param symbol Stock symbol
+   * @param options Optional parameters including abort signal and context
    * @returns Array of stock grades
    */
-  async getStockGrades(symbol: string): Promise<StockGrade[]> {
-    return super.get<StockGrade[]>("/grades", { symbol });
+  async getStockGrades(
+    symbol: string,
+    options?: RequestOptions
+  ): Promise<StockGrade[]> {
+    return super.get<StockGrade[]>("/grades", { symbol }, options);
   }
 
   /**
    * Get historical stock grades for a stock symbol
    * @param symbol Stock symbol
    * @param limit Optional limit on number of results (default: 100, max: 1000)
+   * @param options Optional parameters including abort signal and context
    * @returns Array of historical stock grades
    */
   async getHistoricalStockGrades(
     symbol: string,
-    limit?: number
+    limit?: number,
+    options?: RequestOptions
   ): Promise<HistoricalStockGrade[]> {
-    return super.get<HistoricalStockGrade[]>("/grades-historical", {
-      symbol,
-      limit,
-    });
+    return super.get<HistoricalStockGrade[]>(
+      "/grades-historical",
+      { symbol, limit },
+      options
+    );
   }
 
   /**
    * Get stock grade summary for a stock symbol
    * @param symbol Stock symbol
+   * @param options Optional parameters including abort signal and context
    * @returns Array of stock grade summaries
    */
-  async getStockGradeSummary(symbol: string): Promise<StockGradeSummary[]> {
-    return super.get<StockGradeSummary[]>("/grades-consensus", { symbol });
+  async getStockGradeSummary(
+    symbol: string,
+    options?: RequestOptions
+  ): Promise<StockGradeSummary[]> {
+    return super.get<StockGradeSummary[]>(
+      "/grades-consensus",
+      { symbol },
+      options
+    );
   }
 
   /**
@@ -161,26 +209,38 @@ export class AnalystClient extends FMPClient {
    * @param symbol Stock symbol
    * @param page Optional page number (default: 0)
    * @param limit Optional limit on number of results (default: 1, max: 100)
+   * @param options Optional parameters including abort signal and context
    * @returns Array of stock grade news
    */
   async getStockGradeNews(
     symbol: string,
     page?: number,
-    limit?: number
+    limit?: number,
+    options?: RequestOptions
   ): Promise<StockGradeNews[]> {
-    return super.get<StockGradeNews[]>("/grades-news", { symbol, page, limit });
+    return super.get<StockGradeNews[]>(
+      "/grades-news",
+      { symbol, page, limit },
+      options
+    );
   }
 
   /**
    * Get latest stock grade news for all stocks
    * @param page Optional page number (default: 0, max: 100)
    * @param limit Optional limit on number of results (default: 10, max: 1000)
+   * @param options Optional parameters including abort signal and context
    * @returns Array of stock grade news
    */
   async getStockGradeLatestNews(
     page?: number,
-    limit?: number
+    limit?: number,
+    options?: RequestOptions
   ): Promise<StockGradeNews[]> {
-    return super.get<StockGradeNews[]>("/grades-latest-news", { page, limit });
+    return super.get<StockGradeNews[]>(
+      "/grades-latest-news",
+      { page, limit },
+      options
+    );
   }
 }

--- a/src/api/search/SearchClient.ts
+++ b/src/api/search/SearchClient.ts
@@ -10,6 +10,11 @@ import type {
   ExchangeVariantResult,
 } from "./types.js";
 
+type RequestOptions = {
+  signal?: AbortSignal;
+  context?: FMPContext;
+};
+
 export class SearchClient extends FMPClient {
 
   /**
@@ -17,23 +22,19 @@ export class SearchClient extends FMPClient {
    * @param query The search query
    * @param limit Optional limit on number of results (default: 50)
    * @param exchange Optional exchange filter
-   * @param context Optional context containing configuration
+   * @param options Optional parameters including abort signal and context
    * @returns Array of matching symbols
    */
   async searchSymbol(
     query: string,
     limit?: number,
     exchange?: string,
-    context?: FMPContext
+    options?: RequestOptions
   ): Promise<SymbolSearchResult[]> {
     return super.get<SymbolSearchResult[]>(
       "/search-symbol",
-      {
-        query,
-        limit,
-        exchange,
-      },
-      { context }
+      { query, limit, exchange },
+      options
     );
   }
 
@@ -42,23 +43,19 @@ export class SearchClient extends FMPClient {
    * @param query The search query
    * @param limit Optional limit on number of results (default: 50)
    * @param exchange Optional exchange filter
-   * @param context Optional context containing configuration
+   * @param options Optional parameters including abort signal and context
    * @returns Array of matching companies
    */
   async searchName(
     query: string,
     limit?: number,
     exchange?: string,
-    context?: FMPContext
+    options?: RequestOptions
   ): Promise<NameSearchResult[]> {
     return super.get<NameSearchResult[]>(
       "/search-name",
-      {
-        query,
-        limit,
-        exchange,
-      },
-      { context }
+      { query, limit, exchange },
+      options
     );
   }
 
@@ -66,55 +63,59 @@ export class SearchClient extends FMPClient {
    * Search for companies by CIK number
    * @param cik The CIK number to search for
    * @param limit Optional limit on number of results (default: 50)
-   * @param context Optional context containing configuration
+   * @param options Optional parameters including abort signal and context
    * @returns Array of matching companies
    */
   async searchCIK(
     cik: string,
     limit?: number,
-    context?: FMPContext
+    options?: RequestOptions
   ): Promise<CIKSearchResult[]> {
     return super.get<CIKSearchResult[]>(
       "/search-cik",
       { cik, limit },
-      { context }
+      options
     );
   }
 
   /**
    * Search for securities by CUSIP number
    * @param cusip The CUSIP number to search for
-   * @param context Optional context containing configuration
+   * @param options Optional parameters including abort signal and context
    * @returns Array of matching securities
    */
   async searchCUSIP(
     cusip: string,
-    context?: FMPContext
+    options?: RequestOptions
   ): Promise<CUSIPSearchResult[]> {
     return super.get<CUSIPSearchResult[]>(
       "/search-cusip",
       { cusip },
-      { context }
+      options
     );
   }
 
   /**
    * Search for securities by ISIN number
    * @param isin The ISIN number to search for
-   * @param context Optional context containing configuration
+   * @param options Optional parameters including abort signal and context
    * @returns Array of matching securities
    */
   async searchISIN(
     isin: string,
-    context?: FMPContext
+    options?: RequestOptions
   ): Promise<ISINSearchResult[]> {
-    return super.get<ISINSearchResult[]>("/search-isin", { isin }, { context });
+    return super.get<ISINSearchResult[]>(
+      "/search-isin",
+      { isin },
+      options
+    );
   }
 
   /**
    * Search for stocks using various criteria
    * @param params Search criteria
-   * @param context Optional context containing configuration
+   * @param options Optional parameters including abort signal and context
    * @returns Array of matching stocks
    */
   async stockScreener(
@@ -139,29 +140,29 @@ export class SearchClient extends FMPClient {
       limit?: number;
       includeAllShareClasses?: boolean;
     },
-    context?: FMPContext
+    options?: RequestOptions
   ): Promise<StockScreenerResult[]> {
-    return super.get<StockScreenerResult[]>("/company-screener", params, {
-      context,
-    });
+    return super.get<StockScreenerResult[]>(
+      "/company-screener",
+      params,
+      options
+    );
   }
 
   /**
    * Search for exchange variants of a symbol
    * @param symbol The stock symbol to search for
-   * @param context Optional context containing configuration
+   * @param options Optional parameters including abort signal and context
    * @returns Array of exchange variants
    */
   async searchExchangeVariants(
     symbol: string,
-    context?: FMPContext
+    options?: RequestOptions
   ): Promise<ExchangeVariantResult[]> {
     return super.get<ExchangeVariantResult[]>(
       "/search-exchange-variants",
-      {
-        symbol,
-      },
-      { context }
+      { symbol },
+      options
     );
   }
 }


### PR DESCRIPTION
## Summary

Forward-port of three audit-finding patches from #98, rebuilt cleanly on top of the current `main` (which has substantially diverged since #98 was opened — express→fastify swap, toolception adapter layer, `mcp-server-factory` / `dynamic-toolset-manager` removed, registry tests relocated, etc.). Closes #98 in favor of this focused branch.

Each commit is atomic, individually typecheck-clean, and tested.

## What's in scope

Three of the original eight commits still apply meaningfully against current `main`:

```
7f7b49d refactor(api): tighten FMPClient types, DRY error/config helpers
88438b3 refactor(api): normalize options forwarding in AnalystClient and SearchClient
6443060 test(utils): cover showHelp (7 assertions)
```

## What's intentionally dropped from #98

Verified against current `main`; these are either obsolete, already done, or incompatible with the new architecture:

- **`fix(types)` for 3 pre-existing typecheck errors** — `mcp-server-factory/` was removed; the smithery shim is no longer needed because `@smithery/sdk` is no longer imported anywhere in `src/`.
- **`registerAllTools` dedup** — `src/tools/index.ts` was removed; the new `src/toolception-adapters/coreModuleAdapters.ts` is the registration entry point.
- **227-assertion tools test suite** — depended on `registerAllTools` and `src/tools/index.ts`. Could be re-architected for `ToolCollector` later, but that's a separate PR and the existing `__tests__/unit/toolception-adapters/ToolCollector.test.ts` already covers the collector primitive.
- **Dead-code cleanup** — `mcp-trace`, `DEFAULT_API_KEY`, and `src/utils/index.ts` were all removed by upstream's `feat(repo): quality gates` work.

## Per-commit detail

### `7f7b49d` refactor(api): tighten FMPClient types, DRY error/config helpers

Combines the two FMPClient improvements from #98 into a single change against current `main`. The `feat(repo): quality gates` PR added `{ cause: error }` to all six inline throws without otherwise touching the duplication; this commit consolidates that error handling into one place and tightens the surface.

- **Type tightening**: `FMPErrorResponse[key: string]` and `FMPClient.post()` `data` parameter: `any` → `unknown`. The named `message: string` member is preserved, so `axiosError.response?.data?.message` narrowing still works at the three call sites.
- **DRY refactor**: Extract `buildConfig` (params + apikey + signal + extras) and `toFmpError` (axios + unknown error normalization, preserving `cause`). Three methods × ~30 lines of duplicated catch+config become three methods × ~10 lines that delegate to the helpers.
- **`Record<string, any>` → `object`** on `params` to avoid the well-known TS quirk where typed `XParams` interfaces fail to satisfy `Record<string, unknown>` due to missing index signatures.

File: 170 → 132 lines (-22%). Public surface unchanged. Runtime behavior unchanged. The 22 existing `__tests__/unit/api/FMPClient.test.ts` assertions all pass.

### `88438b3` refactor(api): normalize options forwarding in AnalystClient and SearchClient

19 of 253 client methods across these two clients could not be passed an `AbortSignal` or per-request `context`. Every other client (26 of 29) already accepts and forwards the standard `options?: { signal?: AbortSignal; context?: FMPContext }` shape. This commit aligns the outliers.

**AnalystClient**: 12 methods (`getAnalystEstimates`, `getRatingsSnapshot`, `getHistoricalRatings`, `getPriceTargetSummary`, `getPriceTargetConsensus`, `getPriceTargetNews`, `getPriceTargetLatestNews`, `getStockGrades`, `getHistoricalStockGrades`, `getStockGradeSummary`, `getStockGradeNews`, `getStockGradeLatestNews`) now accept and forward options.

**SearchClient**: 7 methods (`searchSymbol`, `searchName`, `searchCIK`, `searchCUSIP`, `searchISIN`, `stockScreener`, `searchExchangeVariants`). The bespoke `context?: FMPContext` positional trailer is replaced with `options?: RequestOptions`; AbortSignal support is added for the first time on this client. Internal call sites forward options directly instead of wrapping `{ context }` inline.

Test updates are behavior-preserving:
- 2-arg `toHaveBeenCalledWith` assertions are extended to expect the 3rd forwarded argument (`undefined` when no options supplied).
- Test call sites that previously passed `context` positionally now pass `{ context }` to match the unified shape; the underlying forwarding assertion is identical.

All 46 tests in the two affected suites pass.

### `6443060` test(utils): cover showHelp (7 assertions)

`src/utils/showHelp.ts` had no test coverage. The existing `__tests__/unit/utils/utils.test.ts` had a comment indicating intent ("Mock console for showHelp tests") and an unused `_consoleSpy`, but no actual assertions.

New describe block adds 7 tests:
1. writes output to `console.log`
2. includes the server name
3. mentions `DEFAULT_PORT` from `constants/`
4. lists every supplied toolset key, name, and description
5. handles an empty toolset array without throwing
6. includes documented CLI flags (`--port`, `--fmp-token`, `--dynamic-tool-discovery`, `--fmp-tool-sets`, `--help`)
7. documents configuration precedence and environment variables (`FMP_ACCESS_TOKEN`, `DYNAMIC_TOOL_DISCOVERY`, `FMP_TOOL_SETS`, `PORT`)

The block installs its own `console.log` spy per test in `beforeEach` (the module-level `_consoleSpy` gets detached by earlier `vi.restoreAllMocks()` calls and would report zero invocations).

## Validation

```
npm run typecheck:  clean (0 errors)
npm run test:run:   914 passed / 23 pre-existing failures
                    (baseline on this commit's parent is 907/23 - same 23 failures)
```

The 23 pre-existing failures are entirely in `__tests__/unit/registry-tests/` and toolception-adapter Windows-related tests that `spawn('npm', ...)` directly; they fail on this Windows host but pass on Linux/macOS CI. Not introduced by this PR; same failures occur on a clean `main` checkout.

### Coverage on this branch (filtering Windows-broken tests for v8 report)

| Area | % Stmts | Notes |
|---|---|---|
| `src/api/FMPClient.ts` | ~96% | All 3 protected methods exercised |
| `src/api/analyst/` | covered by new options-forwarding assertions | |
| `src/api/search/` | same | |
| `src/utils/showHelp.ts` | new coverage from 7 tests | |

## Test plan

- [x] `npm run typecheck` reports 0 errors
- [x] `npm run test:run` shows 914 passed / 23 pre-existing failures (no new failures)
- [x] `__tests__/unit/api/FMPClient.test.ts`: 22/22
- [x] `__tests__/unit/api/analyst/AnalystClient.test.ts`: 23/23
- [x] `__tests__/unit/api/search/SearchClient.test.ts`: 23/23
- [x] `__tests__/unit/utils/utils.test.ts`: 62/62 (was 55, +7 showHelp tests)

## Notes for reviewers

If you want the dropped pieces revived later:
- The `ToolCollector`-based version of the tool registration test suite is straightforward — port the test logic from #98's `toolRegistration.test.ts` to use `new ToolCollector()` instead of `mockServer.tool`, and verify against the 28 register* functions wired through `coreModuleAdapters.ts`. Happy to follow up with that as a separate PR if of interest.
- The `lint:fix` / `knip:fix` scripts run cleanly on this branch.